### PR TITLE
[expat]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.expat?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # expat
 
 Expat library: Fast XML parser in C

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# expat
+
+Expat library: Fast XML parser in C
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/xmlwf'

--- a/config/fixtures/mismatched-tag.xml
+++ b/config/fixtures/mismatched-tag.xml
@@ -1,0 +1,4 @@
+<doc>
+  <element>One<element>
+</doc>
+

--- a/config/fixtures/valid.xml
+++ b/config/fixtures/valid.xml
@@ -1,0 +1,4 @@
+<doc>
+  <element>One</element>
+</doc>
+

--- a/controls/expat_exists.rb
+++ b/controls/expat_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm expat exists'
+
+plan_name = input('plan_name', value: 'expat')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+expat_relative_path = input('command_path', value: '/bin/xmlwf')
+expat_installation_directory = command("hab pkg path #{plan_ident}")
+expat_full_path = expat_installation_directory.stdout.strip + "#{ expat_relative_path}"
+ 
+control 'core-plans-expat-exists' do
+  impact 1.0
+  title 'Ensure expat exists'
+  desc '
+  '
+   describe file(expat_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/expat_exists.rb
+++ b/controls/expat_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm expat exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'expat')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-expat_relative_path = input('command_path', value: '/bin/xmlwf')
-expat_installation_directory = command("hab pkg path #{plan_ident}")
-expat_full_path = expat_installation_directory.stdout.strip + "#{ expat_relative_path}"
  
 control 'core-plans-expat-exists' do
   impact 1.0
   title 'Ensure expat exists'
   desc '
-  '
-   describe file(expat_full_path) do
+  Verify expat by ensuring /bin/xmlwf exists'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  command_relative_path = input('command_relative_path', value: '/bin/xmlwf')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/expat_works.rb
+++ b/controls/expat_works.rb
@@ -1,0 +1,39 @@
+title 'Tests to confirm expat works as expected'
+
+plan_name = input('plan_name', value: 'expat')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+expat_path = command("hab pkg path #{plan_ident}")
+expat_pkg_ident = ((expat_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+
+control 'core-plans-expat-works-001' do
+  impact 1.0
+  title 'expat binary should exist'
+  describe expat_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+end
+
+control 'core-plans-expat-works-002' do
+  impact 1.0
+  title 'expat should parse well-formed xml'
+  describe command("DEBUG=true; hab pkg exec #{expat_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/valid.xml") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should be_empty }
+    its('stderr') { should be_empty }
+  end
+end
+
+control 'core-plans-expat-works-003' do
+  impact 1.0
+  title 'should report error on malformed xml'
+  describe command("DEBUG=true; hab pkg exec #{expat_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /mismatched tag/ }
+    its('stderr') { should be_empty }
+  end
+
+end
+
+

--- a/controls/expat_works.rb
+++ b/controls/expat_works.rb
@@ -1,33 +1,32 @@
 title 'Tests to confirm expat works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'expat')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-expat_path = command("hab pkg path #{plan_ident}")
-expat_pkg_ident = ((expat_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
-control 'core-plans-expat-works-001' do
+control 'core-plans-expat-works' do
   impact 1.0
-  title 'expat binary should exist'
-  describe expat_path do
+  title 'Ensure expat works as expected'
+  desc '
+  Verify expat by ensuring (1) its installation directory exists and (2) that
+  it successfully parses valid xml and (3) that it reports an error for invalid
+  xml
+  '
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
-end
 
-control 'core-plans-expat-works-002' do
-  impact 1.0
-  title 'expat should parse well-formed xml'
-  describe command("DEBUG=true; hab pkg exec #{expat_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/valid.xml") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/valid.xml") do
     its('exit_status') { should eq 0 }
     its('stdout') { should be_empty }
     its('stderr') { should be_empty }
   end
-end
 
-control 'core-plans-expat-works-003' do
-  impact 1.0
-  title 'should report error on malformed xml'
-  describe command("DEBUG=true; hab pkg exec #{expat_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /mismatched tag/ }

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: expat
+title: Habitat Core Plan expat
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan expat
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,57 @@
+pkg_name=expat
+pkg_origin=core
+pkg_version=2.2.7
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Expat is a stream-oriented XML parser library written in C. Expat excels with \
+files too large to fit RAM, and where performance and flexibility are crucial.\
+"
+pkg_upstream_url="https://libexpat.github.io/"
+pkg_license=('MIT')
+pkg_source="https://downloads.sourceforge.net/project/${pkg_name}/${pkg_name}/${pkg_version}/${pkg_name}-${pkg_version}.tar.bz2"
+pkg_shasum="cbc9102f4a31a8dafd42d642e9a3aa31e79a0aedaa1f6efd2795ebc83174ec18"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_check() {
+  # Remove shebang line containing `/usr/bin/env` in test helper
+  sed -i 's,^#!.*bash$,,' run.sh
+
+  # Set `LDFLAGS` for the c++ test code to find libstdc++
+  make check LDFLAGS="$LDFLAGS -lstdc++"
+}
+
+do_install() {
+  do_default_install
+
+  # Install license file
+  install -Dm644 COPYING "$pkgdir/share/licenses/COPYING"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+  )
+fi

--- a/tests/fixtures/mismatched-tag.xml
+++ b/tests/fixtures/mismatched-tag.xml
@@ -1,0 +1,4 @@
+<doc>
+  <element>One<element>
+</doc>
+

--- a/tests/fixtures/valid.xml
+++ b/tests/fixtures/valid.xml
@@ -1,0 +1,4 @@
+<doc>
+  <element>One</element>
+</doc>
+

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,9 @@
+@test "Parses well-formed xml" {
+  run hab pkg exec $TEST_PKG_IDENT xmlwf $BATS_TEST_DIRNAME/fixtures/valid.xml
+  [ "$output" == "" ]
+}
+
+@test "Reports error on non-well-formed xml" {
+  run hab pkg exec $TEST_PKG_IDENT xmlwf $BATS_TEST_DIRNAME/fixtures/mismatched-tag.xml
+  grep "mismatched tag" <<< "$output"
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://947758d341c2cb920946bd35861c303800d162b422574a3fd422c9b209ad8fb5 --input-file /src/attributes.yml

Profile: Habitat Core Plan expat (expat)
Version: 0.1.0
Target:  docker://947758d341c2cb920946bd35861c303800d162b422574a3fd422c9b209ad8fb5

  ✔  core-plans-expat-works-001: expat binary should exist
     ✔  Command: `hab pkg path core/expat` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/expat` stdout is expected not to be empty
  ✔  core-plans-expat-works-002: expat should parse well-formed xml
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/valid.xml` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/valid.xml` stdout is expected to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/valid.xml` stderr is expected to be empty
  ✔  core-plans-expat-works-003: should report error on malformed xml
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml` stdout is expected to match /mismatched tag/
     ✔  Command: `DEBUG=true; hab pkg exec core/expat/2.2.7/20200602233123 xmlwf /hab/svc/expat/config/fixtures/mismatched-tag.xml` stderr is expected to be empty
  ✔  core-plans-expat-exists: Ensure expat exists
     ✔  File /hab/pkgs/core/expat/2.2.7/20200602233123/bin/xmlwf is expected to exist


Profile Summary: 4 successful controls, 0 control failures, 0 controls skipped
Test Summary: 10 successful, 0 failures, 0 skipped
+ set +x
[6][default:/src:0]# 
```